### PR TITLE
Utiliser la page "à propos"

### DIFF
--- a/Google Chrome/background.js
+++ b/Google Chrome/background.js
@@ -21,7 +21,7 @@ Notificateur.prototype = {
 	/**
 	 * ZdS URL
 	 */
-	url: "http://zestedesavoir.com",
+	url: "https://zestedesavoir.com/pages/apropos/",
 
 	/**
 	 * If logged in last check


### PR DESCRIPTION
 à la place de la page d'accueil. La page à propos étant une page sans contenu dynamique hormis les notifications, elle semble chargement 3x plus vite que la page d'accueil (et demander moins de ressources au serveur du coup je pense). Cela fait également moins de DOM à charger.